### PR TITLE
Fix Greenkeeper config

### DIFF
--- a/doc/source/examples/bots.rst
+++ b/doc/source/examples/bots.rst
@@ -39,8 +39,8 @@ dependencies.
       - name: automatic merge for Greenkeeper pull requests
         conditions:
           - author=greenkeeper[bot]
-          - status-success=Travis CI - Pull Request
-          - status-sucess=greenkeeper/verify
+          - status-success=continuous-integration/travis-ci/pr
+          - status-success=greenkeeper/verify
         actions:
           merge:
             method: merge


### PR DESCRIPTION
The config below is what works for me with Greenkeeper:
```
pull_request_rules:
  - name: automatic merge for Greenkeeper pull requests
    conditions:
      - author=greenkeeper[bot]
      - status-success=continuous-integration/travis-ci/pr
      - status-success=greenkeeper/verify
    actions:
      merge:
        method: merge
```